### PR TITLE
feat: Ability to configure the `origin` of an entity

### DIFF
--- a/src/configuration/component_configuration.ts
+++ b/src/configuration/component_configuration.ts
@@ -23,6 +23,7 @@ SOFTWARE.
 
 import { AvailabilityConfiguration } from './availability_configuration';
 import { DeviceConfiguration } from './device_configuration';
+import { OriginConfiguration } from './origin_configuration';
 
 /**
  * Common configuration interface for Home Assistant MQTT components Contains the base configuration properties shared
@@ -52,6 +53,9 @@ export interface BaseComponentConfiguration {
    * unique_id is set. At least one of identifiers or connections must be present to identify the device.
    */
   device?: DeviceConfiguration;
+
+  /** Information about the application that is the origin of the component. */
+  origin?: OriginConfiguration;
 
   /**
    * Sets the class of the device, changing the device state and icon that is displayed on the frontend. The

--- a/src/configuration/origin_configuration.ts
+++ b/src/configuration/origin_configuration.ts
@@ -1,0 +1,11 @@
+/** Configuration for the origin of an entity. */
+export interface OriginConfiguration {
+  /** The name of the application that is the origin of the discovered MQTT item. */
+  name: string;
+
+  /** Software version of the application that supplies the discovered MQTT item. */
+  sw_version?: string;
+
+  /** Support URL of the application that supplies the discovered MQTT item. */
+  support_url?: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,5 +32,6 @@ export * from './components/switch';
 export * from './configuration/availability_configuration';
 export * from './configuration/component_configuration';
 export * from './configuration/device_configuration';
+export * from './configuration/origin_configuration';
 export * from './lib/logger';
 export * from './lib/utils';

--- a/test-environment/example.ts
+++ b/test-environment/example.ts
@@ -21,7 +21,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-import { BinarySensor, Button, DeviceConfiguration, MqttSettings, Switch } from '@/.';
+import { BinarySensor, Button, DeviceConfiguration, MqttSettings, OriginConfiguration, Switch } from '@/.';
 import { Climate } from '@/components/climate';
 import { pino } from 'pino';
 
@@ -55,6 +55,12 @@ async function main() {
     identifiers: 'my_device_id'
   };
 
+  const origin: OriginConfiguration = {
+    name: 'mqtt2ha example',
+    sw_version: '1.0.0',
+    support_url: 'https://github.com/bourquep/mqtt2ha'
+  };
+
   const myBinarySensor = new BinarySensor({
     mqtt: mqttSettings,
     component: {
@@ -62,7 +68,8 @@ async function main() {
       name: 'MyBinarySensor',
       device_class: 'motion',
       unique_id: 'my_sensor_unique_id',
-      device
+      device,
+      origin
     },
     logger: rootLogger.child({ module: 'binary_sensor' })
   });
@@ -74,7 +81,8 @@ async function main() {
         component: 'button',
         name: 'MyButton',
         unique_id: 'my_button_unique_id',
-        device
+        device,
+        origin
       },
       logger: rootLogger.child({ module: 'button' })
     },
@@ -91,7 +99,8 @@ async function main() {
         component: 'switch',
         name: 'MySwitch',
         unique_id: 'my_switch_unique_id',
-        device
+        device,
+        origin
       },
       logger: rootLogger.child({ module: 'switch' })
     },
@@ -116,6 +125,7 @@ async function main() {
         name: 'MyClimate',
         unique_id: 'my_climate_unique_id',
         device: myThermostat,
+        origin,
         modes: ['off', 'heat'],
         temperature_unit: 'C',
         min_temp: 10,


### PR DESCRIPTION
It is recommended to add information about the origin of MQTT entities by including the origin option (abbreviated as o) in the discovery payload. For device-based discovery, this information is required. The origin details will be logged in the core event log when an item is discovered or updated. Adding origin information helps with troubleshooting and provides valuable context about the source of MQTT messages in your Home Assistant setup.