### PR TITLE
fix: re-publish availability on MQTT reconnect

### DIFF
--- a/src/api/discoverable.ts
+++ b/src/api/discoverable.ts
@@ -169,6 +169,20 @@ export class Discoverable<
     if (onConnect) {
       this.mqttClient.on('connect', onConnect);
     }
+
+    // Re-publish availability on reconnect to recover from stale LWT messages.
+    // When the MQTT broker restarts, the LWT fires and sets the availability
+    // topic to "offline" (retained). The mqtt.js client auto-reconnects, but
+    // writeConfig() is only called once during initial setup — so the "offline"
+    // message persists until the application is fully restarted.
+    if (!this.settings.manual_availability) {
+      this.mqttClient.on('connect', () => {
+        if (this.wroteConfiguration) {
+          this.logger.debug(`Re-publishing availability for ${this.identifier} after reconnect...`);
+          this.setAvailability(true);
+        }
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem

When the MQTT broker restarts, the Last Will and Testament (LWT) fires and publishes `offline` (retained) to each entity's availability topic. The `mqtt.js` client auto-reconnects successfully, but `writeConfig()` — which is the only place that publishes `online` — is only called once during initial setup. This leaves all entities stuck as `unavailable` in Home Assistant until the application process is fully restarted.

This affects any downstream consumer of `mqtt2ha` (e.g. `mysa2mqtt`) — a broker restart makes all entities permanently unavailable even though state data continues flowing normally.

## Fix

Register a `connect` event handler on the MQTT client that re-publishes `online` to the availability topic on every reconnect. The handler is:

- Guarded by `wroteConfiguration` to avoid publishing before initial `writeConfig()` completes
- Only registered when `manual_availability` is not set, consistent with the existing LWT and `writeConfig()` behavior

## Testing

Tested with `mysa2mqtt` v1.2.2 against Mosquitto 2.0.x running in Kubernetes. Verified that:

1. After broker restart, entities recover to `online` without restarting the application
2. LWT still correctly publishes `offline` when the application shuts down
3. Initial startup behavior is unchanged (`wroteConfiguration` guard prevents premature publish)